### PR TITLE
Fixed RestAspectRatio Bug

### DIFF
--- a/Objective-C/TOCropViewController/TOCropViewController.m
+++ b/Objective-C/TOCropViewController/TOCropViewController.m
@@ -558,7 +558,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
 {
     BOOL animated = (self.cropView.angle == 0);
     
-    if (self.resetAspectRatioEnabled) {
+    if (self.resetAspectRatioEnabled && self.requiredAspectRatios == nil) {
         self.aspectRatioLockEnabled = NO;
     }
     
@@ -786,7 +786,7 @@ static const CGFloat kTOCropViewControllerToolbarHeight = 44.0f;
     }
     _requiredAspectRatios = requiredAspectRatios;
     CGSize aspectRatio = [[requiredAspectRatios firstObject] CGSizeValue];
-    [self.cropView setAspectRatio:aspectRatio animated:NO];
+    [self.cropView setDefaultRequiredAspectRatio:aspectRatio animated:NO];
 }
 
 - (void)rotateCropViewClockwise

--- a/Objective-C/TOCropViewController/Views/TOCropView.h
+++ b/Objective-C/TOCropViewController/Views/TOCropView.h
@@ -105,6 +105,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) CGSize aspectRatio;
 
 /**
+ The aspect ratio to set when the user resets the view.
+ */
+@property (nonatomic, assign) CGSize defaultRequiredAspectRatio;
+
+/**
  When the cropping box is locked to its current aspect ratio (But can still be resized)
  */
 @property (nonatomic, assign) BOOL aspectRatioLockEnabled;
@@ -219,6 +224,16 @@ The minimum croping aspect ratio. If set, user is prevented from setting croppin
  @param animated Whether the locking effect is animated
  */
 - (void)setAspectRatio:(CGSize)aspectRatio animated:(BOOL)animated;
+
+/**
+ Changes the aspect ratio of the crop box to match the one specified and sets the aspect ratio to change to when
+ user taps the resetAspectRatio button.
+
+ @param aspectRatio The aspect ratio (For example 16:9 is 16.0f/9.0f). 'CGSizeZero' will reset it to the image's own ratio
+ @param animated Whether the locking effect is animated
+ */
+
+- (void)setDefaultRequiredAspectRatio:(CGSize)aspectRatio animated:(BOOL)animated;
 
 /**
  Rotates the entire canvas to a 90-degree angle. The default rotation is counterclockwise.


### PR DESCRIPTION
ResetAspectRatio was causing a couple of bugs when requiredAspectRatios was set:
1. The aspect ratios button would become unhighlighted.
2. Freeform cropping would become enabled. 
3. No matter what aspect ratio you selected after that, freeform cropping would still be enabled. 